### PR TITLE
Fix repository link in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Device-agnostic X-Powers AXP173 power management IC driver"
 version = "0.1.7"
 authors = ["eupn <eupn@protonmail.com>"]
 edition = "2018"
-repository = "https://github.com/eupn/axp173"
+repository = "https://github.com/eupn/axp173-rs"
 categories = [
     "embedded",
     "hardware-support",


### PR DESCRIPTION
So that crates.io has the right link